### PR TITLE
Add option to fail on no files found

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Add the plugin to your project's `pom.xml`:
 | `schemaVersion` | JSON Schema version (V4, V6, V7, V201909, V202012) | `V202012` | No |
 | `skip` | Skip validation execution | `false` | No |
 | `schemaMappings` | Map schema IDs to local files/directories for $ref resolution | - | No |
+| `failOnNoFilesFound` | Fail build when no files match the include patterns | `true` | No |
 
 ## File Pattern Matching
 
@@ -200,6 +201,9 @@ Here's a complete example POM file showing how to configure the plugin:
                             <schemaMappings>
                                 <schemaMapping>http://example.com/schemas/=src/main/resources/schemas/</schemaMapping>
                             </schemaMappings>
+                            
+                            <!-- Fail when no files found (default: true) -->
+                            <failOnNoFilesFound>true</failOnNoFilesFound>
                         </configuration>
                     </execution>
                 </executions>
@@ -237,3 +241,20 @@ mvn validate -Dschema.validator.skip=true
     <!-- other configuration -->
 </configuration>
 ```
+
+### Controlling Behavior When No Files Are Found
+
+By default, the plugin will fail the build if no files match the include patterns. This helps catch configuration errors early. You can control this behavior with the `failOnNoFilesFound` parameter:
+
+```xml
+<configuration>
+    <!-- Set to false to allow validation to pass when no files are found -->
+    <failOnNoFilesFound>false</failOnNoFilesFound>
+    <!-- other configuration -->
+</configuration>
+```
+
+This is useful in scenarios where:
+- Files might not exist in certain environments
+- You're using the plugin in a multi-module project where some modules might not have files to validate
+- You want validation to be optional based on file availability

--- a/src/test/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojoFailOnNoFilesTest.java
+++ b/src/test/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojoFailOnNoFilesTest.java
@@ -1,0 +1,75 @@
+package com.dataliquid.maven.plugin.schema.validator;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+import com.dataliquid.maven.plugin.schema.validator.JsonYamlValidatorMojo;
+
+public class JsonYamlValidatorMojoFailOnNoFilesTest extends AbstractMojoTestCase {
+
+    public void testFailOnNoFilesFoundDefault() throws Exception {
+        File pom = getTestFile("target/test-classes/test-poms/no-files-found-default-test-pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JsonYamlValidatorMojo mojo = (JsonYamlValidatorMojo) lookupMojo("validate", pom);
+        assertNotNull(mojo);
+        
+        try {
+            mojo.execute();
+            fail("Expected MojoFailureException when no files found with default failOnNoFilesFound=true");
+        } catch (MojoFailureException e) {
+            // Expected exception
+            assertTrue(e.getMessage().contains("No files found matching the include patterns"));
+        }
+    }
+
+    public void testFailOnNoFilesFoundExplicitTrue() throws Exception {
+        File pom = getTestFile("target/test-classes/test-poms/no-files-found-true-test-pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JsonYamlValidatorMojo mojo = (JsonYamlValidatorMojo) lookupMojo("validate", pom);
+        assertNotNull(mojo);
+        
+        try {
+            mojo.execute();
+            fail("Expected MojoFailureException when no files found with failOnNoFilesFound=true");
+        } catch (MojoFailureException e) {
+            // Expected exception
+            assertTrue(e.getMessage().contains("No files found matching the include patterns"));
+            assertTrue(e.getMessage().contains("failOnNoFilesFound=false"));
+        }
+    }
+
+    public void testNoFailOnNoFilesFoundFalse() throws Exception {
+        File pom = getTestFile("target/test-classes/test-poms/no-files-found-false-test-pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JsonYamlValidatorMojo mojo = (JsonYamlValidatorMojo) lookupMojo("validate", pom);
+        assertNotNull(mojo);
+        
+        // Should execute without exception when failOnNoFilesFound=false
+        mojo.execute();
+    }
+
+    public void testNonExistentSourceDirectory() throws Exception {
+        File pom = getTestFile("target/test-classes/test-poms/non-existent-source-dir-test-pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JsonYamlValidatorMojo mojo = (JsonYamlValidatorMojo) lookupMojo("validate", pom);
+        assertNotNull(mojo);
+        
+        try {
+            mojo.execute();
+            fail("Expected MojoFailureException when source directory doesn't exist with default failOnNoFilesFound=true");
+        } catch (MojoFailureException e) {
+            // Expected exception
+            assertTrue(e.getMessage().contains("No files found matching the include patterns"));
+        }
+    }
+}

--- a/src/test/resources/test-poms/no-files-found-default-test-pom.xml
+++ b/src/test/resources/test-poms/no-files-found-default-test-pom.xml
@@ -1,0 +1,21 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.dataliquid</groupId>
+                <artifactId>json-yaml-validator-maven-plugin</artifactId>
+                <configuration>
+                    <schemaFile>target/test-classes/schemas/v4/product-schema-v4.json</schemaFile>
+                    <sourceDirectory>target/test-classes/test-data/non-existent-directory</sourceDirectory>
+                    <includes>
+                        <include>**/*.json</include>
+                        <include>**/*.yaml</include>
+                    </includes>
+                    <schemaVersion>V4</schemaVersion>
+                    <!-- Explicitly set to true to test default behavior -->
+                    <failOnNoFilesFound>true</failOnNoFilesFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-poms/no-files-found-false-test-pom.xml
+++ b/src/test/resources/test-poms/no-files-found-false-test-pom.xml
@@ -1,0 +1,20 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.dataliquid</groupId>
+                <artifactId>json-yaml-validator-maven-plugin</artifactId>
+                <configuration>
+                    <schemaFile>target/test-classes/schemas/v4/product-schema-v4.json</schemaFile>
+                    <sourceDirectory>target/test-classes/test-data/empty-directory</sourceDirectory>
+                    <includes>
+                        <include>**/*.json</include>
+                        <include>**/*.yaml</include>
+                    </includes>
+                    <schemaVersion>V4</schemaVersion>
+                    <failOnNoFilesFound>false</failOnNoFilesFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-poms/no-files-found-true-test-pom.xml
+++ b/src/test/resources/test-poms/no-files-found-true-test-pom.xml
@@ -1,0 +1,20 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.dataliquid</groupId>
+                <artifactId>json-yaml-validator-maven-plugin</artifactId>
+                <configuration>
+                    <schemaFile>target/test-classes/schemas/v4/product-schema-v4.json</schemaFile>
+                    <sourceDirectory>target/test-classes/test-data/empty-directory</sourceDirectory>
+                    <includes>
+                        <include>**/*.json</include>
+                        <include>**/*.yaml</include>
+                    </includes>
+                    <schemaVersion>V4</schemaVersion>
+                    <failOnNoFilesFound>true</failOnNoFilesFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-poms/non-existent-source-dir-test-pom.xml
+++ b/src/test/resources/test-poms/non-existent-source-dir-test-pom.xml
@@ -1,0 +1,21 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.dataliquid</groupId>
+                <artifactId>json-yaml-validator-maven-plugin</artifactId>
+                <configuration>
+                    <schemaFile>target/test-classes/schemas/v4/product-schema-v4.json</schemaFile>
+                    <sourceDirectory>target/test-classes/test-data/this-directory-definitely-does-not-exist</sourceDirectory>
+                    <includes>
+                        <include>**/*.json</include>
+                        <include>**/*.yaml</include>
+                    </includes>
+                    <schemaVersion>V4</schemaVersion>
+                    <!-- Explicitly set to true to test default behavior -->
+                    <failOnNoFilesFound>true</failOnNoFilesFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixes #7

Added `failOnNoFilesFound` parameter to control whether the plugin should fail when no files match the validation patterns. Default is `true` to maintain backward compatibility.

- New configuration parameter in JsonYamlValidatorMojo
- Updated validation logic to respect the new setting
- Added tests for all scenarios
- Updated README documentation