### PR TITLE
Update parent-oss to version 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>filter-test-poms</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,13 @@
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.dataliquid.maven</groupId>
+    <parent>
+        <groupId>com.dataliquid</groupId>
+        <artifactId>parent-oss</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <groupId>com.dataliquid</groupId>
     <artifactId>json-yaml-validator-maven-plugin</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>


### PR DESCRIPTION
## Summary
- Updates parent POM reference to de.dataliquid:parent-oss:2.0.0
- Keeps project aligned with latest parent POM configurations

## Changes
- Added parent POM declaration in pom.xml pointing to parent-oss version 2.0.0

## Test plan
- [ ] Build passes with `mvn clean install`
- [ ] All tests pass with `mvn test`
- [ ] Plugin validation works with `mvn json-yaml-validator:validate`

Fixes #14