### PR TITLE
Skip GPG signing in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         cache: maven
     
     - name: Build with Maven
-      run: mvn clean install -B
+      run: mvn clean install -B -Dgpg.skip=true
     
     - name: Run tests
-      run: mvn test -B
+      run: mvn test -B -Dgpg.skip=true


### PR DESCRIPTION
## Summary
- Adds GPG signing skip parameter to Maven commands in CI workflow
- Prevents GPG signing failures during automated builds

## Problem
The GitHub Actions build was failing with:
```
Error: Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:3.2.7:sign (sign-gpg) on project json-yaml-validator-maven-plugin: Exit code: 2
```

## Solution
Added `-Dgpg.skip=true` parameter to Maven commands in the CI workflow to skip GPG signing during automated builds.

## Changes
- Updated `.github/workflows/ci.yml` to add `-Dgpg.skip=true` to `mvn clean install` and `mvn test` commands

## Test plan
- [ ] CI build passes without GPG signing errors
- [ ] Tests run successfully in GitHub Actions
- [ ] GPG signing still available for release builds when needed

Fixes #16