### PR TITLE
Add Maven Central badge and update version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JSON/YAML Validator Maven Plugin
 
 [![CI Build](https://github.com/dataliquid/json-yaml-validator-maven-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/dataliquid/json-yaml-validator-maven-plugin/actions/workflows/ci.yml)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.dataliquid/json-yaml-validator-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.dataliquid/json-yaml-validator-maven-plugin)
 
 A Maven plugin for validating JSON and YAML files against a JSON Schema using the [networknt/json-schema-validator](https://github.com/networknt/json-schema-validator) library.
 
@@ -27,7 +28,7 @@ Add the plugin to your project's `pom.xml`:
         <plugin>
             <groupId>com.dataliquid.maven</groupId>
             <artifactId>json-yaml-validator-maven-plugin</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
             <executions>
                 <execution>
                     <id>validate-json-yaml</id>
@@ -164,7 +165,7 @@ Here's a complete example POM file showing how to configure the plugin:
             <plugin>
                 <groupId>com.dataliquid.maven</groupId>
                 <artifactId>json-yaml-validator-maven-plugin</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>validate-json-yaml</id>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>filter-test-poms</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,13 @@
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.dataliquid.maven</groupId>
+    <parent>
+        <groupId>com.dataliquid</groupId>
+        <artifactId>parent-oss</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <groupId>com.dataliquid</groupId>
     <artifactId>json-yaml-validator-maven-plugin</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>


### PR DESCRIPTION
## Summary
- Added Maven Central version badge to README
- Updated plugin version to reflect latest release

## Changes
- Added Maven Central badge displaying latest available version
- Updated version from 1.0.0-SNAPSHOT to 1.0.0 in all usage examples

## Motivation
The badge provides immediate visibility of the latest available version on Maven Central, making it easier for users to:
- See the latest version available on Maven Central
- Have accurate version information in the documentation

Fixes #18