### PR TITLE
Add Gitflow workflows with proper permissions

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -1,0 +1,29 @@
+name: Gitflow Hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Gitflow action to perform'
+        required: true
+        type: choice
+        options:
+          - hotfix-start
+          - hotfix-finish
+      version:
+        description: 'Hotfix version (e.g., 1.17.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  hotfix:
+    uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@1.0.0
+    with:
+      action: ${{ inputs.action }}
+      version: ${{ inputs.version }}
+      java-version: '8'
+      java-distribution: 'temurin'

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -1,0 +1,29 @@
+name: Gitflow Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Gitflow action to perform'
+        required: true
+        type: choice
+        options:
+          - release-start
+          - release-finish
+      version:
+        description: 'Release version (optional for auto-detection)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@1.0.0
+    with:
+      action: ${{ inputs.action }}
+      version: ${{ inputs.version }}
+      java-version: '8'
+      java-distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Add gitflow-release workflow with auto-detection support for release branches
- Add gitflow-hotfix workflow for emergency fixes
- Include proper permissions for contents and pull-requests write access
- Uses reusable workflows from dataliquid/github-actions@1.0.0

## Why permissions are needed
- `contents: write` - Required to create branches, push commits, and create tags
- `pull-requests: write` - Required if the workflow needs to create or modify pull requests

## Test plan
- [ ] Verify workflows appear in Actions tab after merge
- [ ] Test release-start action creates new release branch
- [ ] Test release-finish action with auto-detection when single release branch exists
- [ ] Test hotfix-start action creates new hotfix branch
- [ ] Test hotfix-finish action merges back to master and develop