### PR TITLE
Fix GitHub Actions Java version to match project requirements

### DIFF
--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '8'
+      java-version: '11'
       java-distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Updated Java version from 8 to 11 in gitflow-release.yml workflow to fix compilation error

## Test plan
- GitHub Actions release workflow should complete successfully