### PR TITLE
#38 Update to use maven.compiler.release property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,7 @@
     <description>Maven plugin for validating JSON and YAML files using json-schema-validator</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
         <json-schema-validator.version>1.5.8</json-schema-validator.version>


### PR DESCRIPTION
## Summary
- Replace maven.compiler.source and maven.compiler.target with maven.compiler.release=11
- Maintains Java 11 compatibility as required

## Test plan
- [x] Build passes with `mvn clean install`
- [x] Tests pass successfully
- [x] Plugin still works with Java 11 projects