### PR TITLE
#42 Replace maven.compiler.release with source/target properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
     <description>Maven plugin for validating JSON and YAML files using json-schema-validator</description>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
         <json-schema-validator.version>1.5.8</json-schema-validator.version>


### PR DESCRIPTION
## Summary
- Replaced maven.compiler.release property with maven.compiler.source and maven.compiler.target properties due to a known bug

## Test plan
- [x] CI build passes
- [x] Project compiles successfully with mvn clean compile
- [x] All tests pass