### PR TITLE
#52 Fix YAML aliases being treated as strings

### DIFF
--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
@@ -1,7 +1,8 @@
 package com.dataliquid.maven.plugin.schema.validator;
 
 import java.io.File;
-import java.io.IOException;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ import com.dataliquid.maven.plugin.schema.validator.utils.AntPatternFileFilter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.Yaml;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
@@ -67,8 +68,9 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
     private boolean failOnNoFilesFound;
 
     private final ObjectMapper jsonMapper = new ObjectMapper();
-    private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+    private final ObjectMapper yamlMapper = new ObjectMapper();
 
+    
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
@@ -253,7 +255,12 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
     private JsonNode readFile(File file) throws IOException {
         String fileName = file.getName().toLowerCase(Locale.ROOT);
         if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) {
-            return yamlMapper.readTree(file);
+            Yaml snakeYaml = new Yaml();
+            Object loadedYaml;
+            try (InputStream in = new FileInputStream(file)) {
+                loadedYaml = snakeYaml.load(in);
+            }
+            return yamlMapper.valueToTree(loadedYaml);
         } else {
             return jsonMapper.readTree(file);
         }

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
@@ -71,7 +71,6 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
     private final ObjectMapper jsonMapper = new ObjectMapper();
     private final ObjectMapper yamlMapper = new ObjectMapper();
 
-    
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
@@ -1,6 +1,7 @@
 package com.dataliquid.maven.plugin.schema.validator;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
@@ -257,7 +257,7 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
         if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) {
             Yaml snakeYaml = new Yaml();
             Object loadedYaml;
-            try (InputStream in = new FileInputStream(file)) {
+            try (InputStream in = Files.newInputStream(file.toPath())) {
                 loadedYaml = snakeYaml.load(in);
             }
             return yamlMapper.valueToTree(loadedYaml);

--- a/src/test/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojoV201909Test.java
+++ b/src/test/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojoV201909Test.java
@@ -138,4 +138,18 @@ public class JsonYamlValidatorMojoV201909Test extends AbstractMojoTestCase {
             assertTrue(e.getMessage().contains("Validation failed"));
         }
     }
+
+    public void testV201909ValidEventWithYamlAliases() throws Exception {
+        File pom = getTestFile("target/test-classes/test-poms/v201909-yaml-aliases-test-pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JsonYamlValidatorMojo mojo = (JsonYamlValidatorMojo) lookupMojo("validate", pom);
+        assertNotNull(mojo);
+
+        // Should execute without exception - tests YAML anchors and aliases
+        // This specifically tests that YAML aliases are resolved to their actual values
+        // and not treated as strings (Issue #52)
+        mojo.execute();
+    }
 }

--- a/src/test/resources/test-data/v201909/valid/event-with-imports-valid.yaml
+++ b/src/test/resources/test-data/v201909/valid/event-with-imports-valid.yaml
@@ -2,8 +2,8 @@ eventId: EVT-20240620
 title: Virtual DevOps Summit
 description: Online conference for DevOps professionals
 location:
-  latitude: 0
-  longitude: 0
+  latitude: &zero 0
+  longitude: *zero
   timestamp: "2024-02-01T12:00:00Z"
 venue:
   name: Virtual Conference Platform

--- a/src/test/resources/test-data/v201909/valid/event-with-imports-valid.yaml
+++ b/src/test/resources/test-data/v201909/valid/event-with-imports-valid.yaml
@@ -2,8 +2,8 @@ eventId: EVT-20240620
 title: Virtual DevOps Summit
 description: Online conference for DevOps professionals
 location:
-  latitude: &zero 0
-  longitude: *zero
+  latitude: 0
+  longitude: 0
   timestamp: "2024-02-01T12:00:00Z"
 venue:
   name: Virtual Conference Platform

--- a/src/test/resources/test-data/v201909/valid/event-yaml-aliases.yaml
+++ b/src/test/resources/test-data/v201909/valid/event-yaml-aliases.yaml
@@ -1,0 +1,21 @@
+# Issue #52: YAML aliases treated as strings
+eventId: EVT-20241111
+title: YAML Alias Test Event
+description: Test that YAML aliases are resolved correctly
+location:
+  latitude: &zero 0
+  longitude: *zero
+  timestamp: "2024-02-01T12:00:00Z"
+venue:
+  name: Test Venue
+  type: online
+  capacity:
+    maximum: 1000
+schedule:
+  start: "2024-06-20T13:00:00Z"
+  end: "2024-06-20T21:00:00Z"
+  timezone: Europe/Berlin
+registration:
+  required: true
+  url: "https://example.com/register"
+  deadline: "2024-06-19T23:59:59Z"

--- a/src/test/resources/test-poms/v201909-yaml-aliases-test-pom.xml
+++ b/src/test/resources/test-poms/v201909-yaml-aliases-test-pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.dataliquid.maven</groupId>
+    <artifactId>v201909-yaml-aliases-test</artifactId>
+    <version>1.0.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.dataliquid.maven</groupId>
+                <artifactId>json-yaml-validator-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <schemaFile>${basedir}/src/test/resources/schemas/v201909/event-with-imports.json</schemaFile>
+                    <sourceDirectory>${basedir}/src/test/resources/test-data/v201909/valid</sourceDirectory>
+                    <includes>
+                        <include>event-yaml-aliases.yaml</include>
+                    </includes>
+                    <schemaVersion>V201909</schemaVersion>
+                    <failOnError>true</failOnError>
+                    <schemaMappings>
+                        <schemaMapping>http://example.com/schemas/v201909/=${basedir}/src/test/resources/schemas/v201909/</schemaMapping>
+                    </schemaMappings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixes #52 - YAML aliases were incorrectly treated as string literals instead of their referenced values.

Added SnakeYAML for proper YAML alias resolution and a dedicated test to verify the fix.