### PR TITLE
#63 Upgrade networknt json-schema-validator to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
-        <json-schema-validator.version>2.0.0</json-schema-validator.version>
+        <json-schema-validator.version>2.0.1</json-schema-validator.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Upgrade networknt json-schema-validator from 2.0.0 to 2.0.1 for latest bugfixes

Closes #63

## Test plan
- [x] Build passes: `mvn clean install`
- [x] All unit tests pass