### PR TITLE
#65 Upgrade to Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '17', '21' ]
-    
-    name: Build with Java ${{ matrix.java }}
-    
+    name: Build with Java 25
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up JDK ${{ matrix.java }}
+
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: ${{ matrix.java }}
+        java-version: '25'
         distribution: 'temurin'
         cache: maven
     

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Maven plugin for validating JSON and YAML files against a JSON Schema using th
 
 ## Requirements
 
-- Java 11 or higher
+- Java 17 or higher
 - Maven 3.6.0 or higher
 
 ## Features

--- a/pom.xml
+++ b/pom.xml
@@ -13,15 +13,15 @@
 
     <groupId>com.dataliquid.maven</groupId>
     <artifactId>json-yaml-validator-maven-plugin</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>JSON/YAML Validator Maven Plugin</name>
     <description>Maven plugin for validating JSON and YAML files using json-schema-validator</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
         <json-schema-validator.version>2.0.1</json-schema-validator.version>

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/ErrorMatchingResult.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/ErrorMatchingResult.java
@@ -5,16 +5,18 @@ import java.util.Set;
 /**
  * Result of matching expected errors against actual errors.
  */
-class ErrorMatchingResult {
-    private final Set<String> matchedPatterns;
-    private final Set<String> unmatchedPatterns;
-    private final Set<String> unexpectedErrors;
+record ErrorMatchingResult(Set<String> matchedPatterns, Set<String> unmatchedPatterns, Set<String> unexpectedErrors) {
 
-    public ErrorMatchingResult(Set<String> matchedPatterns, Set<String> unmatchedPatterns,
-            Set<String> unexpectedErrors) {
-        this.matchedPatterns = matchedPatterns;
-        this.unmatchedPatterns = unmatchedPatterns;
-        this.unexpectedErrors = unexpectedErrors;
+    public boolean hasUnmatchedPatterns() {
+        return !unmatchedPatterns.isEmpty();
+    }
+
+    public boolean hasUnexpectedErrors() {
+        return !unexpectedErrors.isEmpty();
+    }
+
+    public boolean isFullMatch() {
+        return !hasUnmatchedPatterns() && !hasUnexpectedErrors();
     }
 
     public Set<String> getMatchedPatterns() {
@@ -27,17 +29,5 @@ class ErrorMatchingResult {
 
     public Set<String> getUnexpectedErrors() {
         return unexpectedErrors;
-    }
-
-    public boolean hasUnmatchedPatterns() {
-        return !unmatchedPatterns.isEmpty();
-    }
-
-    public boolean hasUnexpectedErrors() {
-        return !unexpectedErrors.isEmpty();
-    }
-
-    public boolean isFullMatch() {
-        return !hasUnmatchedPatterns() && !hasUnexpectedErrors();
     }
 }

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
@@ -198,20 +198,14 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
     }
 
     private SpecificationVersion getSchemaVersion() throws MojoExecutionException {
-        switch (schemaVersion.toUpperCase(Locale.ROOT)) {
-        case "V4":
-            return SpecificationVersion.DRAFT_4;
-        case "V6":
-            return SpecificationVersion.DRAFT_6;
-        case "V7":
-            return SpecificationVersion.DRAFT_7;
-        case "V201909":
-            return SpecificationVersion.DRAFT_2019_09;
-        case "V202012":
-            return SpecificationVersion.DRAFT_2020_12;
-        default:
-            throw new MojoExecutionException("Unsupported schema version: " + schemaVersion);
-        }
+        return switch (schemaVersion.toUpperCase(Locale.ROOT)) {
+        case "V4" -> SpecificationVersion.DRAFT_4;
+        case "V6" -> SpecificationVersion.DRAFT_6;
+        case "V7" -> SpecificationVersion.DRAFT_7;
+        case "V201909" -> SpecificationVersion.DRAFT_2019_09;
+        case "V202012" -> SpecificationVersion.DRAFT_2020_12;
+        default -> throw new MojoExecutionException("Unsupported schema version: " + schemaVersion);
+        };
     }
 
     private List<ValidationResult> validateFiles(Schema schema) throws IOException, MojoFailureException {

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/ValidationResult.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/ValidationResult.java
@@ -8,21 +8,14 @@ import com.networknt.schema.Error;
 /**
  * Result of validating a single file against a JSON schema.
  */
-class ValidationResult {
-    private final File file;
-    private final List<Error> errors;
-    private final Exception exception;
+record ValidationResult(File file, List<Error> errors, Exception exception) {
 
     public ValidationResult(File file, List<Error> errors) {
-        this.file = file;
-        this.errors = errors;
-        this.exception = null;
+        this(file, errors, null);
     }
 
     public ValidationResult(File file, Exception exception) {
-        this.file = file;
-        this.errors = null;
-        this.exception = exception;
+        this(file, null, exception);
     }
 
     public boolean isValid() {


### PR DESCRIPTION
## Summary
- Upgrade project to Java 17 (major version bump to 2.0.0)
- CI pipeline now uses Java 25 only
- Refactored to use Java 17 language features:
  - `ValidationResult` → Record
  - `ErrorMatchingResult` → Record
  - `getSchemaVersion()` → Switch Expression

## Test plan
- [x] Build passes locally: `mvn clean install`
- [x] All unit tests pass
- [x] CI pipeline passes with Java 25