### PR TITLE
Upgrade to json-schema-validator 3.0.0 and Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
-        <json-schema-validator.version>2.0.1</json-schema-validator.version>
+        <json-schema-validator.version>3.0.0</json-schema-validator.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,23 @@
             <version>${json-schema-validator.version}</version>
         </dependency>
 
-        <!-- Jackson for JSON/YAML parsing -->
+        <!-- Jackson 3 for JSON/YAML parsing -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.20.1</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.20.1</version>
+            <version>3.0.3</version>
+        </dependency>
+
+        <!-- SnakeYAML for proper YAML merge key (<<) resolution -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.5</version>
         </dependency>
 
         <!-- Apache Commons IO for file operations -->

--- a/pom.xml
+++ b/pom.xml
@@ -55,19 +55,11 @@
             <version>${json-schema-validator.version}</version>
         </dependency>
 
-        <!-- Jackson 3 for JSON/YAML parsing -->
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>3.0.3</version>
         </dependency>
-        <dependency>
-            <groupId>tools.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>3.0.3</version>
-        </dependency>
-
-        <!-- SnakeYAML for proper YAML merge key (<<) resolution -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
+++ b/src/main/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojo.java
@@ -26,8 +26,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import com.dataliquid.maven.plugin.schema.validator.utils.AntPatternFileFilter;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 import org.yaml.snakeyaml.Yaml;
 import com.networknt.schema.Error;
 import com.networknt.schema.Schema;
@@ -83,8 +83,7 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
     @Parameter(property = "schema.validator.strictErrorMatching", defaultValue = "false")
     private boolean strictErrorMatching;
 
-    private final ObjectMapper jsonMapper = new ObjectMapper();
-    private final ObjectMapper yamlMapper = new ObjectMapper();
+    private final JsonMapper jsonMapper = JsonMapper.builder().build();
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -261,12 +260,13 @@ public class JsonYamlValidatorMojo extends AbstractMojo {
     private JsonNode readFile(File file) throws IOException {
         String fileName = file.getName().toLowerCase(Locale.ROOT);
         if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) {
+            // Use SnakeYAML for proper YAML merge key (<<) resolution
             Yaml snakeYaml = new Yaml();
             Object loadedYaml;
             try (InputStream in = Files.newInputStream(file.toPath())) {
                 loadedYaml = snakeYaml.load(in);
             }
-            return yamlMapper.valueToTree(loadedYaml);
+            return jsonMapper.valueToTree(loadedYaml);
         } else {
             return jsonMapper.readTree(file);
         }

--- a/src/test/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojoV201909Test.java
+++ b/src/test/java/com/dataliquid/maven/plugin/schema/validator/JsonYamlValidatorMojoV201909Test.java
@@ -138,4 +138,18 @@ public class JsonYamlValidatorMojoV201909Test extends AbstractMojoTestCase {
             assertTrue(e.getMessage().contains("Validation failed"));
         }
     }
+
+    public void testV201909ValidEventWithYamlAliases() throws Exception {
+        File pom = getTestFile("target/test-classes/test-poms/v201909-yaml-aliases-test-pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JsonYamlValidatorMojo mojo = (JsonYamlValidatorMojo) lookupMojo("validate", pom);
+        assertNotNull(mojo);
+
+        // Should execute without exception - tests YAML anchors and aliases
+        // This specifically tests that YAML aliases are resolved to their actual values
+        // and not treated as strings (Issue #52)
+        mojo.execute();
+    }
 }

--- a/src/test/resources/test-data/v201909/valid/event-yaml-aliases.yaml
+++ b/src/test/resources/test-data/v201909/valid/event-yaml-aliases.yaml
@@ -1,0 +1,21 @@
+# Issue #52: YAML aliases treated as strings
+eventId: EVT-20241111
+title: YAML Alias Test Event
+description: Test that YAML aliases are resolved correctly
+location:
+  latitude: &zero 0
+  longitude: *zero
+  timestamp: "2024-02-01T12:00:00Z"
+venue:
+  name: Test Venue
+  type: online
+  capacity:
+    maximum: 1000
+schedule:
+  start: "2024-06-20T13:00:00Z"
+  end: "2024-06-20T21:00:00Z"
+  timezone: Europe/Berlin
+registration:
+  required: true
+  url: "https://example.com/register"
+  deadline: "2024-06-19T23:59:59Z"

--- a/src/test/resources/test-poms/v201909-yaml-aliases-test-pom.xml
+++ b/src/test/resources/test-poms/v201909-yaml-aliases-test-pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.dataliquid.maven</groupId>
+    <artifactId>v201909-yaml-aliases-test</artifactId>
+    <version>1.0.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.dataliquid.maven</groupId>
+                <artifactId>json-yaml-validator-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <schemaFile>${basedir}/src/test/resources/schemas/v201909/event-with-imports.json</schemaFile>
+                    <sourceDirectory>${basedir}/src/test/resources/test-data/v201909/valid</sourceDirectory>
+                    <includes>
+                        <include>event-yaml-aliases.yaml</include>
+                    </includes>
+                    <schemaVersion>V201909</schemaVersion>
+                    <failOnError>true</failOnError>
+                    <schemaMappings>
+                        <schemaMapping>http://example.com/schemas/v201909/=${basedir}/src/test/resources/schemas/v201909/</schemaMapping>
+                    </schemaMappings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Summary
- Upgrade networknt json-schema-validator from 2.0.1 to 3.0.0
- Upgrade Jackson from 2.x to 3.0.3 (new package: `tools.jackson`)
- Add SnakeYAML 2.5 for proper YAML alias resolution (Jackson 3 doesn't resolve aliases)
- Remove unused jackson-dataformat-yaml dependency
- Restore YAML alias test (accidentally deleted in #51)

## Test plan
- [x] All 55 unit tests pass
- [x] YAML alias test passes (`event-yaml-aliases.yaml`)
- [x] Build succeeds with `mvn clean install`
- [x] CI pipeline passes